### PR TITLE
checking `tsd-lite`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/__typetests__/index.test.ts
+++ b/__typetests__/index.test.ts
@@ -1,0 +1,5 @@
+import { expectType } from "tsd-lite";
+import { sum, diff } from "simple-math";
+
+expectType<number>(sum(1, 2));
+expectType<number>(diff(2, 1));

--- a/jest.config.tsd.js
+++ b/jest.config.tsd.js
@@ -1,0 +1,10 @@
+const config = {
+  displayName: {
+    color: "blue",
+    name: "types",
+  },
+  runner: "jest-runner-tsd",
+  testMatch: ["**/__typetests__/*.test.ts"],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
   "scripts": {
     "check": "npm run ts-check && npm run tsd-check",
     "ts-check": "tsc",
-    "tsd-check": "tsd"
+    "tsd-check": "tsd",
+    "test:types": "jest -c jest.config.tsd.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "jest": "^29.5.0",
+    "jest-runner-tsd": "^4.0.0",
     "tsd": "^0.26.0",
     "typescript": "^4.9.5"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"index.d.ts",
 		"index.js",
 		"lib",
-		"test-d"
+		"test-d",
+		"__typetests__"
 	]
 }


### PR DESCRIPTION
(Oh sorry.. Note went missing.)

I am maintainer of [`tsd-lite`](https://github.com/mrazauskas/tsd-lite), which helps to solve some limitations of `tsd`.

The issue you opened in `tsd` made me curious to check your case. All works with `tsd-lite` as you can see in this branch.

You can use `tsd-lite` with Jest (by the way, it is used to test Jest’s types). There is also a CLI implementation from the community. See: https://github.com/mrazauskas/tsd-lite